### PR TITLE
#8: Allow possibility to save the current page in history before redirecting

### DIFF
--- a/Resources/private/js/bluetea/ajaxProtocol.js
+++ b/Resources/private/js/bluetea/ajaxProtocol.js
@@ -93,11 +93,13 @@ $(function() {
                     this.createModal(data.content);
                     break;
                 case 'redirect':
-                    if('useHistory' in data.data && data.data.useHistory === true) {
-                        history.pushState({}, window.location.href);
+                    // Redirect to page, if useHistory is present allow the saving of
+                    // the current page into history. If not just replace the URL
+                    if('data' in data && 'useHistory' in data.data && data.data.useHistory === true) {
+                        window.location.href = data.content;
+                    } else {
+                        window.location.replace(data.content);
                     }
-                    // Redirect to page
-                    window.location.replace(data.content);
                     break;
                 case 'event':
                     // Fire a custom event

--- a/Resources/private/js/bluetea/ajaxProtocol.js
+++ b/Resources/private/js/bluetea/ajaxProtocol.js
@@ -93,6 +93,9 @@ $(function() {
                     this.createModal(data.content);
                     break;
                 case 'redirect':
+                    if('useHistory' in data.data && data.data.useHistory === true) {
+                        history.pushState({}, window.location.href);
+                    }
                     // Redirect to page
                     window.location.replace(data.content);
                     break;


### PR DESCRIPTION
As explained in #8, there was an issue where when using TYPE_REDIRECT, the current page would no longer be accessible via the back button. 

This PR adds the possibility for you to add a 'useHistory' boolean parameter to data.data. When this is given, the js will add the current page before redirecting